### PR TITLE
Fix for missing full working directory on Run; Additional debugging info

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -43,7 +43,10 @@ export function compile(
       outputChannel.append(proc.stderr.toString());
     } else {
       outputChannel.append(`${outputFile} successfully compiled`);
-      return outputFile;
+
+      // Need to return full path to outputFile because VICE uses it to 
+      // run the file.
+      return path.join(workDir, outputFile);
     }
   }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,13 +1,21 @@
 import * as path from 'path';
-import { workspace } from 'vscode';
+import { workspace, OutputChannel } from 'vscode';
 import { spawn } from 'child_process';
 
 export type DebugOptions = {
   debug?: boolean;
 };
 
-export function run(file?: string | void, options: DebugOptions = {}) {
+export function run(
+  file?: string | void, 
+  outputChannel?: OutputChannel | void, 
+  options: DebugOptions = {}
+) {
   if (!file) {
+    return;
+  }
+
+  if (!outputChannel) {
     return;
   }
 
@@ -63,6 +71,13 @@ export function run(file?: string | void, options: DebugOptions = {}) {
     stdio: 'inherit',
     shell: true,
   };
+
+  // Helpful debugging information
+  outputChannel.appendLine("");
+  outputChannel.appendLine("************************************************************");
+  outputChannel.appendLine('Running command   : ' + command);
+  outputChannel.appendLine('  with args       : ' + JSON.stringify(args));
+  outputChannel.appendLine('  and spawnOptions: ' + JSON.stringify(spawnOptions));
 
   spawn(command, args, spawnOptions);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,12 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposable);
 
   disposable = vscode.commands.registerCommand('64tass.build-run', () =>
-    run(compile(outputChannel))
+    run(compile(outputChannel), outputChannel)
   );
   context.subscriptions.push(disposable);
 
   disposable = vscode.commands.registerCommand('64tass.build-debug', () =>
-    run(compile(outputChannel, { debug: true }), { debug: true })
+    run(compile(outputChannel, { debug: true }), outputChannel, { debug: true })
   );
   context.subscriptions.push(disposable);
 }


### PR DESCRIPTION
This pull request fixes the Run portion by returning the full path of the output .PRG from compile(). The run() function uses this path to run the PRG from VICE, but if it isn't in the current working directory VICE fails silently.

It also adds the run parameters to the outputChannel so that you can debug why VICE isn't running.